### PR TITLE
don't automagically flash on make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ CFILES   = $(wildcard src/*.c)
 CXXFILES = $(wildcard src/*.cc)
 OBJECTS  = ${CFILES:src/%.c=build/%.o} ${CXXFILES:src/%.cc=build/%.o} ${ASFILES:src/%.S=build/%.o}
 
-all: build build/main.elf flash
+all: build build/main.elf
 
 build:
 	mkdir -p build


### PR DESCRIPTION
'make' should only build the software, not flash the device. that's what 'make flash' is for, which is also what the README says.
therefore, this pull request removes the flash part from 'make all'