### PR TITLE
Firmware option for wrong display type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ ifeq (${LANG},DE)
 	SHARED_FLAGS += -DLANG_DE
 endif
 
+ifeq (${INVERTED},1)
+        SHARED_FLAGS += -DINVERTED
+endif
+
 CFLAGS += ${SHARED_FLAGS} -std=c11
 CXXFLAGS += ${SHARED_FLAGS} -std=c++11 -fno-rtti -fno-exceptions
 

--- a/README.md
+++ b/README.md
@@ -75,3 +75,9 @@ presence anymore"). This is quite improbable, though.
 
 Please remove and insert the battery again. Make sure that the battery has enough
 current and replcace the battery if the LED are dark.
+
+## Wrong display ordered
+
+If you ordered the wrong display (AS instead BS variant, e.g. for Mini Rocket 
+788AS (Common Cathode) instead 788BS (Common Anode), you can set the build 
+parameter `INVERTED=1` to build a corresponding firmware.

--- a/src/display.cc
+++ b/src/display.cc
@@ -1,6 +1,5 @@
 /*
  * Copyright (C) 2016 by Birte Kristina Friesel
- * patched for Common Cathode (AS) display type by Patrick Schwarz, 2025-09-18
  *
  * License: You may use, redistribute and/or modify this file under the terms
  * of either:
@@ -32,7 +31,13 @@ Display::Display()
 void Display::disable()
 {
 	TIMSK0 &= ~_BV(TOIE0);
+	
+	#ifdef INVERTED
+	PORTB = 0xFF;
+	#else
 	PORTB = 0;
+	#endif
+	
 	PORTD = 0;
 }
 
@@ -54,7 +59,12 @@ void Display::multiplex()
 	 * To avoid flickering, do not put any code (or expensive index
 	 * calculations) between the following three lines.
 	 */
+	#ifdef INVERTED
+	PORTB = 0xFF;
+	#else
 	PORTB = 0;
+	#endif
+	
 	PORTD = disp_buf[active_col];
 	
 	#ifdef INVERTED
@@ -248,8 +258,15 @@ void Display::update() {
 
 void Display::reset()
 {
-	for (uint8_t i = 0; i < 8; i++)
+	for (uint8_t i = 0; i < 8; i++) {
+		#ifdef INVERTED
+		disp_buf[i] = 0x00;
+		#else
 		disp_buf[i] = 0xff;
+		#endif
+	}
+	
+		
 	update_cnt = 0;
 	repeat_cnt = 0;
 	str_pos = 0;

--- a/src/display.cc
+++ b/src/display.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 by Birte Kristina Friesel
+ * patched for Common Cathode (AS) display type by Patrick Schwarz, 2025-09-18
  *
  * License: You may use, redistribute and/or modify this file under the terms
  * of either:
@@ -55,7 +56,12 @@ void Display::multiplex()
 	 */
 	PORTB = 0;
 	PORTD = disp_buf[active_col];
+	
+	#ifdef INVERTED
+	PORTB = ~_BV(active_col);
+	#else
 	PORTB = _BV(active_col);
+	#endif
 
 	if (++active_col == 8) {
 		active_col = 0;
@@ -109,21 +115,41 @@ void Display::update() {
 				 */
 				if (current_anim->direction == 0) {
 					if (char_pos == 0) {
+						#ifdef INVERTED
+						disp_buf[7] = 0x00; // whitespace
+						#else
 						disp_buf[7] = 0xff; // whitespace
+						#endif
 					} else {
+						#ifdef INVERTED
+						disp_buf[7] = pgm_read_byte(&glyph_addr[char_pos]);
+						#else
 						disp_buf[7] = ~pgm_read_byte(&glyph_addr[char_pos]);
+						#endif
 					}
 				} else {
 					if (char_pos == 0) {
+						#ifdef INVERTED
+						disp_buf[0] = 0x00; // whitespace
+						#else
 						disp_buf[0] = 0xff; // whitespace
+						#endif
 					} else {
+						#ifdef INVERTED
+						disp_buf[0] = pgm_read_byte(&glyph_addr[glyph_len - char_pos + 1]);
+						#else
 						disp_buf[0] = ~pgm_read_byte(&glyph_addr[glyph_len - char_pos + 1]);
+						#endif
 					}
 				}
 
 			} else if (current_anim->type == AnimationType::FRAMES) {
 				for (i = 0; i < 8; i++) {
+					#ifdef INVERTED
+					disp_buf[i] = current_anim->data[str_pos+i];
+					#else
 					disp_buf[i] = ~current_anim->data[str_pos+i];
+					#endif
 				}
 				str_pos += 8;
 			}

--- a/src/system.h
+++ b/src/system.h
@@ -12,7 +12,7 @@
 
 // to display firmware version (v2.1) when storage is empty on first turn on
 #define FW_REV_MAJOR  2
-#define FW_REV_MINOR  1
+#define FW_REV_MINOR  2
 
 
 


### PR DESCRIPTION
If the wrong display type was ordered/delivered (for Mini Rocket 788AS instead 788BS), with the option INVERTED=1 a firmware can be built to also use this display type.